### PR TITLE
Fixes to run example

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: PETDiagnostics
 Title: Diagnostics for the OMOP perinatal expansion (OMOP)
-Version: v0.4
+Version: 0.4
 Authors@R: 
     person("Theresa", "Burkard", , "theresa.burkard@ndorms.ox.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1313-4473"))

--- a/R/MockDB.R
+++ b/R/MockDB.R
@@ -324,23 +324,23 @@ mockPregnancy <- function(mothertable = NULL,
                     overwrite = TRUE)
 
 
-  cdm <- CDMConnector::cdm_from_con(db,
-                                    cdm_schema = "main",
-                                    write_schema = "main",
+  cdm <- CDMConnector::cdmFromCon(db,
+                                    cdmSchema = "main",
+                                    writeSchema = "main",
   )
-  write_schema = "main"
+  writeSchema = "main"
 
-    DBI::dbWriteTable(db, CDMConnector::inSchema(write_schema, "mothertable"),
+    DBI::dbWriteTable(db, CDMConnector::inSchema(writeSchema, "mothertable"),
                       mothertable,
                       overwrite = TRUE)
 
 
-    DBI::dbWriteTable(db, CDMConnector::inSchema(write_schema, "babytable"),
+    DBI::dbWriteTable(db, CDMConnector::inSchema(writeSchema, "babytable"),
                       babytable,
                       overwrite = TRUE)
 
-    cdm$babytable <- dplyr::tbl(db, CDMConnector::inSchema(write_schema, "babytable"))
-    cdm$mothertable <- dplyr::tbl(db, CDMConnector::inSchema(write_schema, "mothertable"))
+    cdm$babytable <- dplyr::tbl(db, CDMConnector::inSchema(writeSchema, "babytable"))
+    cdm$mothertable <- dplyr::tbl(db, CDMConnector::inSchema(writeSchema, "mothertable"))
 
   return(cdm)
 }

--- a/docs/articles/Run this.html
+++ b/docs/articles/Run this.html
@@ -117,9 +117,9 @@ data<a class="anchor" aria-label="anchor" href="#the-name-of-the-schema-that-con
 <div class="section level5">
 <h5 id="create-cdm-reference">create cdm reference<a class="anchor" aria-label="anchor" href="#create-cdm-reference"></a>
 </h5>
-<p>cdm &lt;- CDMConnector::cdm_from_con(con,<br>
-cdm_schema = cdm_database_schema,<br>
-write_schema = results_database_schema)</p>
+<p>cdm &lt;- CDMConnector::cdmFromCon(con,<br>
+cdmSchema = cdm_database_schema,<br>
+writeSchema = results_database_schema)</p>
 </div>
 <div class="section level5">
 <h5 id="add-your-table-to-the-cdm-and-call-it-mothertable-and-babytable-if-present">add your table to the cdm and call it mothertable and babytable (if

--- a/extras/GenerateMockDataset.R
+++ b/extras/GenerateMockDataset.R
@@ -269,9 +269,9 @@ DBI::dbWriteTable(con, "babytable",
                   babytable,
                   overwrite = TRUE)
 
-cdm <- CDMConnector::cdm_from_con(con,
-                                  cdm_schema = "main",
-                                  write_schema = "main")
+cdm <- CDMConnector::cdmFromCon(con,
+                                  cdmSchema = "main",
+                                  writeSchema = "main")
 
 cdm$babytable <- dplyr::tbl(con, "babytable")
 cdm$mothertable <- dplyr::tbl(con, "mothertable")

--- a/extras/run_this.R
+++ b/extras/run_this.R
@@ -23,18 +23,18 @@ con <- DBI::dbConnect(RPostgres::Postgres(),
 
 
 # The name of the schema that contains the OMOP CDM with patient-level data
-cdm_database_schema<-Sys.getenv("DB_CDM_SCHEMA")
+cdm_database_schema<-Sys.getenv("DB_cdmSchema")
 
 # The name of the schema that contains the vocabularies
 vocabulary_database_schema<-cdm_database_schema
 
 # The name of the schema where results tables will be created
-results_database_schema<-Sys.getenv("DB_WRITE_SCHEMA")
+results_database_schema<-Sys.getenv("DB_writeSchema")
 
 # create cdm reference ----
-cdm <- CDMConnector::cdm_from_con(con ,
-                                  cdm_schema = cdm_database_schema,
-                                  write_schema = results_database_schema)
+cdm <- CDMConnector::cdmFromCon(con ,
+                                  cdmSchema = cdm_database_schema,
+                                  writeSchema = results_database_schema)
 
 ## add your table to the cdm and call it motherTable and babyTable (if present)
 cdm$motherTable <- dplyr::tbl(con, sql("SELECT * FROM CDM_NAME.TABLE_NAME"))

--- a/tests/testthat/test-bitSetOverview.R
+++ b/tests/testthat/test-bitSetOverview.R
@@ -91,23 +91,23 @@ test_that("check working example of bit set creation", {
                     overwrite = TRUE)
 
 
-  cdm <- CDMConnector::cdm_from_con(db,
-                                    cdm_schema = "main",
-                                    write_schema = "main",
+  cdm <- CDMConnector::cdmFromCon(db,
+                                    cdmSchema = "main",
+                                    writeSchema = "main",
   )
-  write_schema = "main"
+  writeSchema = "main"
 
-  DBI::dbWriteTable(db, CDMConnector::inSchema(write_schema, "mt"),
+  DBI::dbWriteTable(db, CDMConnector::inSchema(writeSchema, "mt"),
                     mt,
                     overwrite = TRUE)
 
 
-  DBI::dbWriteTable(db, CDMConnector::inSchema(write_schema, "bt"),
+  DBI::dbWriteTable(db, CDMConnector::inSchema(writeSchema, "bt"),
                     bt,
                     overwrite = TRUE)
 
-  cdm$bt <- dplyr::tbl(db, CDMConnector::inSchema(write_schema, "bt"))
-  cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(write_schema, "mt"))
+  cdm$bt <- dplyr::tbl(db, CDMConnector::inSchema(writeSchema, "bt"))
+  cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(writeSchema, "mt"))
 
 
 ## do not know what to test

--- a/tests/testthat/test-checkFetusId.R
+++ b/tests/testthat/test-checkFetusId.R
@@ -94,24 +94,24 @@ test_that("check working example 1) each count 2) counts add up to total", {
 
 
 
-  cdm <- CDMConnector::cdm_from_con(db,
-                                    cdm_schema = "main",
-                                    write_schema = "main",
+  cdm <- CDMConnector::cdmFromCon(db,
+                                    cdmSchema = "main",
+                                    writeSchema = "main",
   )
 
-  write_schema = "main"
+  writeSchema = "main"
 
-  DBI::dbWriteTable(db, CDMConnector::inSchema(write_schema, "mt"),
+  DBI::dbWriteTable(db, CDMConnector::inSchema(writeSchema, "mt"),
                     mt,
                     overwrite = TRUE)
 
 
-  DBI::dbWriteTable(db, CDMConnector::inSchema(write_schema, "bt"),
+  DBI::dbWriteTable(db, CDMConnector::inSchema(writeSchema, "bt"),
                     bt,
                     overwrite = TRUE)
 
-  cdm$bt <- dplyr::tbl(db, CDMConnector::inSchema(write_schema, "bt"))
-  cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(write_schema, "mt"))
+  cdm$bt <- dplyr::tbl(db, CDMConnector::inSchema(writeSchema, "bt"))
+  cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(writeSchema, "mt"))
 
 
   seeFetId <- checkFetusId(cdm$mt,cdm$bt)

--- a/tests/testthat/test-checkFetusesLiveborn.R
+++ b/tests/testthat/test-checkFetusesLiveborn.R
@@ -81,18 +81,18 @@ test_that("check working example 1) each count 2) adds up to total", {
 
 
 
-  cdm <- CDMConnector::cdm_from_con(db,
-                                    cdm_schema = "main",
-                                    write_schema = "main",
+  cdm <- CDMConnector::cdmFromCon(db,
+                                    cdmSchema = "main",
+                                    writeSchema = "main",
   )
 
-  write_schema = "main"
+  writeSchema = "main"
 
-  DBI::dbWriteTable(db, CDMConnector::inSchema(write_schema, "mt"),
+  DBI::dbWriteTable(db, CDMConnector::inSchema(writeSchema, "mt"),
                     mt,
                     overwrite = TRUE)
 
-  cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(write_schema, "mt"))
+  cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(writeSchema, "mt"))
 
   testData <- cdm$mt
 

--- a/tests/testthat/test-checkOutcomeMode.R
+++ b/tests/testthat/test-checkOutcomeMode.R
@@ -82,18 +82,18 @@ test_that("check working example 1) each count 2) adds up to total", {
 
 
 
-  cdm <- CDMConnector::cdm_from_con(db,
-                                    cdm_schema = "main",
-                                    write_schema = "main",
+  cdm <- CDMConnector::cdmFromCon(db,
+                                    cdmSchema = "main",
+                                    writeSchema = "main",
   )
 
-  write_schema = "main"
+  writeSchema = "main"
 
-  DBI::dbWriteTable(db, CDMConnector::inSchema(write_schema, "mt"),
+  DBI::dbWriteTable(db, CDMConnector::inSchema(writeSchema, "mt"),
                     mt,
                     overwrite = TRUE)
 
-  cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(write_schema, "mt"))
+  cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(writeSchema, "mt"))
 
   testData <- cdm$mt
   seeOutMode <- checkOutcomeMode(testData)

--- a/tests/testthat/test-executeChecks.R
+++ b/tests/testthat/test-executeChecks.R
@@ -79,17 +79,17 @@ test_that("check working example if only mother Table is provided", {
                     overwrite = TRUE)
 
 
-  cdm <- CDMConnector::cdm_from_con(db,
-                                    cdm_schema = "main",
-                                    write_schema = "main",
+  cdm <- CDMConnector::cdmFromCon(db,
+                                    cdmSchema = "main",
+                                    writeSchema = "main",
   )
-  write_schema = "main"
+  writeSchema = "main"
 
-  DBI::dbWriteTable(db, CDMConnector::inSchema(write_schema, "mt"),
+  DBI::dbWriteTable(db, CDMConnector::inSchema(writeSchema, "mt"),
                     mt,
                     overwrite = TRUE)
 
-  cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(write_schema, "mt"))
+  cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(writeSchema, "mt"))
 
 
   testData <- cdm$mt
@@ -172,17 +172,17 @@ test_that("check working example if only baby Table is provided", {
                     overwrite = TRUE)
 
 
-  cdm <- CDMConnector::cdm_from_con(db,
-                                    cdm_schema = "main",
-                                    write_schema = "main",
+  cdm <- CDMConnector::cdmFromCon(db,
+                                    cdmSchema = "main",
+                                    writeSchema = "main",
   )
-  write_schema = "main"
+  writeSchema = "main"
 
-  DBI::dbWriteTable(db, CDMConnector::inSchema(write_schema, "bt"),
+  DBI::dbWriteTable(db, CDMConnector::inSchema(writeSchema, "bt"),
                     bt,
                     overwrite = TRUE)
 
-  cdm$bt <- dplyr::tbl(db, CDMConnector::inSchema(write_schema, "bt"))
+  cdm$bt <- dplyr::tbl(db, CDMConnector::inSchema(writeSchema, "bt"))
 
 
   testData <- cdm$bt

--- a/tests/testthat/test-getAnnualOverview.R
+++ b/tests/testthat/test-getAnnualOverview.R
@@ -80,17 +80,17 @@ test_that("check working example annual number of pregnancies", {
                     overwrite = TRUE)
 
 
-  cdm <- CDMConnector::cdm_from_con(db,
-                                    cdm_schema = "main",
-                                    write_schema = "main",
+  cdm <- CDMConnector::cdmFromCon(db,
+                                    cdmSchema = "main",
+                                    writeSchema = "main",
   )
-  write_schema = "main"
+  writeSchema = "main"
 
-  DBI::dbWriteTable(db, CDMConnector::inSchema(write_schema, "mt"),
+  DBI::dbWriteTable(db, CDMConnector::inSchema(writeSchema, "mt"),
                     mt,
                     overwrite = TRUE)
 
-  cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(write_schema, "mt"))
+  cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(writeSchema, "mt"))
 
   testData <- cdm$mt
 

--- a/tests/testthat/test-getBitSet.R
+++ b/tests/testthat/test-getBitSet.R
@@ -94,24 +94,24 @@ test_that("check working example of bit set creation with both tables", {
                     overwrite = TRUE)
 
 
-  cdm <- CDMConnector::cdm_from_con(db,
-                                    cdm_schema = "main",
-                                    write_schema = "main",
+  cdm <- CDMConnector::cdmFromCon(db,
+                                    cdmSchema = "main",
+                                    writeSchema = "main",
   )
 
-  write_schema = "main"
+  writeSchema = "main"
 
-  DBI::dbWriteTable(db, CDMConnector::inSchema(write_schema, "mt"),
+  DBI::dbWriteTable(db, CDMConnector::inSchema(writeSchema, "mt"),
                     mt,
                     overwrite = TRUE)
 
 
-  DBI::dbWriteTable(db, CDMConnector::inSchema(write_schema, "bt"),
+  DBI::dbWriteTable(db, CDMConnector::inSchema(writeSchema, "bt"),
                     bt,
                     overwrite = TRUE)
 
-  cdm$bt <- dplyr::tbl(db, CDMConnector::inSchema(write_schema, "bt"))
-  cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(write_schema, "mt"))
+  cdm$bt <- dplyr::tbl(db, CDMConnector::inSchema(writeSchema, "bt"))
+  cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(writeSchema, "mt"))
 
 
   seeBitSet <- getBitSet(cdm$mt,cdm$bt)
@@ -204,18 +204,18 @@ test_that("check working example of bit set creation with mother table only", {
                     overwrite = TRUE)
 
 
-  cdm <- CDMConnector::cdm_from_con(db,
-                                    cdm_schema = "main",
-                                    write_schema = "main",
+  cdm <- CDMConnector::cdmFromCon(db,
+                                    cdmSchema = "main",
+                                    writeSchema = "main",
   )
 
-  write_schema = "main"
+  writeSchema = "main"
 
-  DBI::dbWriteTable(db, CDMConnector::inSchema(write_schema, "mt"),
+  DBI::dbWriteTable(db, CDMConnector::inSchema(writeSchema, "mt"),
                     mt,
                     overwrite = TRUE)
 
-  cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(write_schema, "mt"))
+  cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(writeSchema, "mt"))
 
   seeBitSet <- getBitSet(cdm$mt , babytable = NULL)
 
@@ -293,18 +293,18 @@ test_that("check working example of bit set creation with baby table only", {
                     overwrite = TRUE)
 
 
-  cdm <- CDMConnector::cdm_from_con(db,
-                                    cdm_schema = "main",
-                                    write_schema = "main",
+  cdm <- CDMConnector::cdmFromCon(db,
+                                    cdmSchema = "main",
+                                    writeSchema = "main",
   )
 
-  write_schema = "main"
+  writeSchema = "main"
 
-  DBI::dbWriteTable(db, CDMConnector::inSchema(write_schema, "bt"),
+  DBI::dbWriteTable(db, CDMConnector::inSchema(writeSchema, "bt"),
                     bt,
                     overwrite = TRUE)
 
-  cdm$bt <- dplyr::tbl(db, CDMConnector::inSchema(write_schema, "bt"))
+  cdm$bt <- dplyr::tbl(db, CDMConnector::inSchema(writeSchema, "bt"))
 
 
   seeBitSet <- getBitSet(mothertable = NULL,cdm$bt)

--- a/tests/testthat/test-getMissings.R
+++ b/tests/testthat/test-getMissings.R
@@ -81,17 +81,17 @@ test_that("check working example 1) missing 2) Total equals fetus size", {
                     overwrite = TRUE)
 
 
-  cdm <- CDMConnector::cdm_from_con(db,
-                                    cdm_schema = "main",
-                                    write_schema = "main",
+  cdm <- CDMConnector::cdmFromCon(db,
+                                    cdmSchema = "main",
+                                    writeSchema = "main",
   )
-  write_schema = "main"
+  writeSchema = "main"
 
-  DBI::dbWriteTable(db, CDMConnector::inSchema(write_schema, "mt"),
+  DBI::dbWriteTable(db, CDMConnector::inSchema(writeSchema, "mt"),
                     mt,
                     overwrite = TRUE)
 
-  cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(write_schema, "mt"))
+  cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(writeSchema, "mt"))
 
   testData <- cdm$mt
 
@@ -169,18 +169,18 @@ test_that("check working example 1) each count 2) Total equals pregnancy size", 
 
 
 
-  cdm <- CDMConnector::cdm_from_con(db,
-                                    cdm_schema = "main",
-                                    write_schema = "main",
+  cdm <- CDMConnector::cdmFromCon(db,
+                                    cdmSchema = "main",
+                                    writeSchema = "main",
   )
 
-  write_schema = "main"
+  writeSchema = "main"
 
-  DBI::dbWriteTable(db, CDMConnector::inSchema(write_schema, "bt"),
+  DBI::dbWriteTable(db, CDMConnector::inSchema(writeSchema, "bt"),
                     bt,
                     overwrite = TRUE)
 
-  cdm$bt <- dplyr::tbl(db, CDMConnector::inSchema(write_schema, "bt"))
+  cdm$bt <- dplyr::tbl(db, CDMConnector::inSchema(writeSchema, "bt"))
 
   testData <- cdm$bt
 

--- a/tests/testthat/test-getOverview.R
+++ b/tests/testthat/test-getOverview.R
@@ -81,17 +81,17 @@ test_that("check working example number or rows equal number of pregnancies", {
                     overwrite = TRUE)
 
 
-  cdm <- CDMConnector::cdm_from_con(db,
-                                    cdm_schema = "main",
-                                    write_schema = "main",
+  cdm <- CDMConnector::cdmFromCon(db,
+                                    cdmSchema = "main",
+                                    writeSchema = "main",
   )
-  write_schema = "main"
+  writeSchema = "main"
 
-  DBI::dbWriteTable(db, CDMConnector::inSchema(write_schema, "mt"),
+  DBI::dbWriteTable(db, CDMConnector::inSchema(writeSchema, "mt"),
                     mt,
                     overwrite = TRUE)
 
-  cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(write_schema, "mt"))
+  cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(writeSchema, "mt"))
 
   testData <- cdm$mt
 
@@ -165,17 +165,17 @@ test_that("check working example number or rows equal number of fetuses", {
                     overwrite = TRUE)
 
 
-  cdm <- CDMConnector::cdm_from_con(db,
-                                    cdm_schema = "main",
-                                    write_schema = "main",
+  cdm <- CDMConnector::cdmFromCon(db,
+                                    cdmSchema = "main",
+                                    writeSchema = "main",
   )
-  write_schema = "main"
+  writeSchema = "main"
 
-  DBI::dbWriteTable(db, CDMConnector::inSchema(write_schema, "bt"),
+  DBI::dbWriteTable(db, CDMConnector::inSchema(writeSchema, "bt"),
                     bt,
                     overwrite = TRUE)
 
-  cdm$bt <- dplyr::tbl(db, CDMConnector::inSchema(write_schema, "bt"))
+  cdm$bt <- dplyr::tbl(db, CDMConnector::inSchema(writeSchema, "bt"))
 
   testData <- cdm$bt
 

--- a/tests/testthat/test-getUnknown.R
+++ b/tests/testthat/test-getUnknown.R
@@ -81,17 +81,17 @@ test_that("check working example number of unknowns", {
                     overwrite = TRUE)
 
 
-  cdm <- CDMConnector::cdm_from_con(db,
-                                    cdm_schema = "main",
-                                    write_schema = "main",
+  cdm <- CDMConnector::cdmFromCon(db,
+                                    cdmSchema = "main",
+                                    writeSchema = "main",
   )
-  write_schema = "main"
+  writeSchema = "main"
 
-  DBI::dbWriteTable(db, CDMConnector::inSchema(write_schema, "mt"),
+  DBI::dbWriteTable(db, CDMConnector::inSchema(writeSchema, "mt"),
                     mt,
                     overwrite = TRUE)
 
-  cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(write_schema, "mt"))
+  cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(writeSchema, "mt"))
 
   testData <- cdm$mt
 

--- a/tests/testthat/test-getValueDatesAgeDist.R
+++ b/tests/testthat/test-getValueDatesAgeDist.R
@@ -80,17 +80,17 @@ test_that("check working example date and Gestage distribution", {
                     overwrite = TRUE)
 
 
-  cdm <- CDMConnector::cdm_from_con(db,
-                                    cdm_schema = "main",
-                                    write_schema = "main",
+  cdm <- CDMConnector::cdmFromCon(db,
+                                    cdmSchema = "main",
+                                    writeSchema = "main",
   )
-  write_schema = "main"
+  writeSchema = "main"
 
-  DBI::dbWriteTable(db, CDMConnector::inSchema(write_schema, "mt"),
+  DBI::dbWriteTable(db, CDMConnector::inSchema(writeSchema, "mt"),
                     mt,
                     overwrite = TRUE)
 
-  cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(write_schema, "mt"))
+  cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(writeSchema, "mt"))
   testData <- cdm$mt
 
   seeOverview <- getValueDatesAgeDist(testData)

--- a/tests/testthat/test-getValueWeightDist.R
+++ b/tests/testthat/test-getValueWeightDist.R
@@ -60,17 +60,17 @@ test_that("check working example birth weight distribution", {
                     overwrite = TRUE)
 
 
-  cdm <- CDMConnector::cdm_from_con(db,
-                                    cdm_schema = "main",
-                                    write_schema = "main",
+  cdm <- CDMConnector::cdmFromCon(db,
+                                    cdmSchema = "main",
+                                    writeSchema = "main",
   )
-  write_schema = "main"
+  writeSchema = "main"
 
-  DBI::dbWriteTable(db, CDMConnector::inSchema(write_schema, "bt"),
+  DBI::dbWriteTable(db, CDMConnector::inSchema(writeSchema, "bt"),
                     bt,
                     overwrite = TRUE)
 
-  cdm$bt <- dplyr::tbl(db, CDMConnector::inSchema(write_schema, "bt"))
+  cdm$bt <- dplyr::tbl(db, CDMConnector::inSchema(writeSchema, "bt"))
 
   seeWeightDist <- getValueWeightDist(cdm$bt)
 

--- a/tests/testthat/test-summariseGestationalAge.R
+++ b/tests/testthat/test-summariseGestationalAge.R
@@ -80,17 +80,17 @@ test_that("check working example 1) each count 2) adds up to total", {
                    overwrite = TRUE)
 
 
- cdm <- CDMConnector::cdm_from_con(db,
-                                   cdm_schema = "main",
-                                   write_schema = "main",
+ cdm <- CDMConnector::cdmFromCon(db,
+                                   cdmSchema = "main",
+                                   writeSchema = "main",
  )
- write_schema = "main"
+ writeSchema = "main"
 
- DBI::dbWriteTable(db, CDMConnector::inSchema(write_schema, "mt"),
+ DBI::dbWriteTable(db, CDMConnector::inSchema(writeSchema, "mt"),
                    mt,
                    overwrite = TRUE)
 
- cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(write_schema, "mt"))
+ cdm$mt <- dplyr::tbl(db, CDMConnector::inSchema(writeSchema, "mt"))
 
  testData <- cdm$mt
 

--- a/vignettes/Run this.Rmd
+++ b/vignettes/Run this.Rmd
@@ -47,9 +47,9 @@ vocabulary_database_schema<-cdm_database_schema
 results_database_schema<-Sys.getenv("DB_WRITE_SCHEMA")
 
 ##### create cdm reference
-cdm <- CDMConnector::cdm_from_con(con,  
-                                  cdm_schema = cdm_database_schema,  
-                                  write_schema = results_database_schema)  
+cdm <- CDMConnector::cdmFromCon(con,  
+                                  cdmSchema = cdm_database_schema,  
+                                  writeSchema = results_database_schema)  
 
 ##### add your table to the cdm and call it mothertable and babytable (if present)
 cdm$mothertable <- dplyr::tbl(con, sql("SELECT * FROM CDM_NAME.TABLE_NAME"))  


### PR DESCRIPTION
- Numeric version number (0.4), fixes #28 
- Refactor for CdmConnector camelcase function and argument names
- Use `mothertable` instead of `motherTable`